### PR TITLE
Adds a default value

### DIFF
--- a/src/iterable-value-converter.js
+++ b/src/iterable-value-converter.js
@@ -1,5 +1,5 @@
 export class IterableValueConverter {
-  toView(value) {
+  toView(value = {}) {
     let index = 0;
     let propKeys = Reflect.ownKeys(value);
     return {


### PR DESCRIPTION
`Reflect.ownKeys(value);` throws an error if the value is not an object.
